### PR TITLE
Add check for reverse proxy setups

### DIFF
--- a/cmd/endpoint.go
+++ b/cmd/endpoint.go
@@ -915,33 +915,35 @@ func CreatePoolEndpoints(serverAddr string, poolArgs ...[][]string) ([]Endpoints
 		}
 
 		orchestrated := IsKubernetes() || IsDocker()
-		if !orchestrated {
+		reverseProxy := (env.Get("_MINIO_REVERSE_PROXY", "") != "") && ((env.Get("MINIO_CI_CD", "") != "") || (env.Get("CI", "") != ""))
+		// If not orchestrated
+		if !orchestrated &&
+			// and not setup in reverse proxy
+			!reverseProxy {
 			// Check whether same path is not used in endpoints of a host on different port.
 			// Only verify this on baremetal setups, DNS is not available in orchestrated
 			// environments so we can't do much here.
-			{
-				pathIPMap := make(map[string]set.StringSet)
-				hostIPCache := make(map[string]set.StringSet)
-				for _, endpoint := range endpoints {
-					host := endpoint.Hostname()
-					hostIPSet, ok := hostIPCache[host]
-					if !ok {
-						var err error
-						hostIPSet, err = getHostIP(host)
-						if err != nil {
-							return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("host '%s' cannot resolve: %s", host, err))
-						}
-						hostIPCache[host] = hostIPSet
+			pathIPMap := make(map[string]set.StringSet)
+			hostIPCache := make(map[string]set.StringSet)
+			for _, endpoint := range endpoints {
+				host := endpoint.Hostname()
+				hostIPSet, ok := hostIPCache[host]
+				if !ok {
+					var err error
+					hostIPSet, err = getHostIP(host)
+					if err != nil {
+						return nil, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("host '%s' cannot resolve: %s", host, err))
 					}
-					if IPSet, ok := pathIPMap[endpoint.Path]; ok {
-						if !IPSet.Intersection(hostIPSet).IsEmpty() {
-							return nil, setupType,
-								config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("same path '%s' can not be served by different port on same address", endpoint.Path))
-						}
-						pathIPMap[endpoint.Path] = IPSet.Union(hostIPSet)
-					} else {
-						pathIPMap[endpoint.Path] = hostIPSet
+					hostIPCache[host] = hostIPSet
+				}
+				if IPSet, ok := pathIPMap[endpoint.Path]; ok {
+					if !IPSet.Intersection(hostIPSet).IsEmpty() {
+						return nil, setupType,
+							config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("same path '%s' can not be served by different port on same address", endpoint.Path))
 					}
+					pathIPMap[endpoint.Path] = IPSet.Union(hostIPSet)
+				} else {
+					pathIPMap[endpoint.Path] = hostIPSet
 				}
 			}
 		}
@@ -1113,32 +1115,34 @@ func CreateEndpoints(serverAddr string, args ...[]string) (Endpoints, SetupType,
 	}
 
 	orchestrated := IsKubernetes() || IsDocker()
-	if !orchestrated {
+	reverseProxy := (env.Get("_MINIO_REVERSE_PROXY", "") != "") && ((env.Get("MINIO_CI_CD", "") != "") || (env.Get("CI", "") != ""))
+	// If not orchestrated
+	if !orchestrated &&
+		// and not setup in reverse proxy
+		!reverseProxy {
 		// Check whether same path is not used in endpoints of a host on different port.
 		// Only verify this on baremetal setups, DNS is not available in orchestrated
 		// environments so we can't do much here.
-		{
-			pathIPMap := make(map[string]set.StringSet)
-			hostIPCache := make(map[string]set.StringSet)
-			for _, endpoint := range endpoints {
-				host := endpoint.Hostname()
-				hostIPSet, ok := hostIPCache[host]
-				if !ok {
-					hostIPSet, err = getHostIP(host)
-					if err != nil {
-						return endpoints, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("host '%s' cannot resolve: %s", host, err))
-					}
-					hostIPCache[host] = hostIPSet
+		pathIPMap := make(map[string]set.StringSet)
+		hostIPCache := make(map[string]set.StringSet)
+		for _, endpoint := range endpoints {
+			host := endpoint.Hostname()
+			hostIPSet, ok := hostIPCache[host]
+			if !ok {
+				hostIPSet, err = getHostIP(host)
+				if err != nil {
+					return endpoints, setupType, config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("host '%s' cannot resolve: %s", host, err))
 				}
-				if IPSet, ok := pathIPMap[endpoint.Path]; ok {
-					if !IPSet.Intersection(hostIPSet).IsEmpty() {
-						return endpoints, setupType,
-							config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("same path '%s' can not be served by different port on same address", endpoint.Path))
-					}
-					pathIPMap[endpoint.Path] = IPSet.Union(hostIPSet)
-				} else {
-					pathIPMap[endpoint.Path] = hostIPSet
+				hostIPCache[host] = hostIPSet
+			}
+			if IPSet, ok := pathIPMap[endpoint.Path]; ok {
+				if !IPSet.Intersection(hostIPSet).IsEmpty() {
+					return endpoints, setupType,
+						config.ErrInvalidErasureEndpoints(nil).Msg(fmt.Sprintf("same path '%s' can not be served by different port on same address", endpoint.Path))
 				}
+				pathIPMap[endpoint.Path] = IPSet.Union(hostIPSet)
+			} else {
+				pathIPMap[endpoint.Path] = hostIPSet
 			}
 		}
 	}


### PR DESCRIPTION
Add check for reverse proxy setups, to skip check for paths being served by different port on same address.

## Community Contribution License
All community contributions in this pull request are licensed to the project maintainers
under the terms of the [Apache 2 license] (https://www.apache.org/licenses/LICENSE-2.0). 
By creating this pull request I represent that I have the right to license the 
contributions to the project maintainers under the Apache 2 license.

## Description
In a minio multi node cluster, we may run multiple minio processes behind multiple reverse proxy servers. In this situation,  the following error is encountered, and prevents minio startup. This error is invalid in a reverse proxy setup:
```
ERROR Invalid command line arguments: same path '/tmp/data1' can not be served by different port on same address
```
See https://github.com/minio/minio/blob/master/cmd/endpoint.go#L917

The solution here is to use a new environment variable `_MINIO_REVERSE_PROXY` to indicate a reverse proxy and therefore skip the above test.  This new variable will be used in conjunction with the existing environment variables: `CI` and `MINIO_CI_CD`.

Essentially, 
if `CI=true or MINIO_CI_CD=true is set and _MINIO_REVERSE_PROXY is set`
then skip check for whether the same path is used in endpoints of a host on different port.


## Motivation and Context
When running multiple reverse proxy servers, the hosts are not all on the same network. Routing may be achieved over the internet using FQDNs. If the same server address handles multiple reverse proxied hosts, then the resolved IP addresses of these reverse proxied hosts are all reported as the same - thus the above error.

This sort of setup should be possible on minio i.e multiple reverse proxy servers handling multiple reverse proxied hosts, where the resolved IP addresses of these reverse proxied hosts are all reported as the same.

## How to test this PR?
Create a minio cluster with multiple reverse proxy servers handling multiple reverse proxied hosts, where the resolved IP addresses of these reverse proxied hosts are all reported as the same.

The cluster should be able to be load balanced and should be accessible. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Unit tests added/updated
- [ ] Internal documentation updated
- [ ] Create a documentation update request [here](https://github.com/minio/docs/issues/new?label=doc-change,title=Doc+Updated+Needed+For+PR+github.com%2fminio%2fminio%2fpull%2fNNNNN)
